### PR TITLE
Improvements to library load

### DIFF
--- a/R/TabPFN-fit.R
+++ b/R/TabPFN-fit.R
@@ -417,7 +417,7 @@ tab_pfn_bridge <- function(processed, options, ...) {
 # Implementation
 
 tab_pfn_impl <- function(x, y, opts) {
-  tabpfn <- reticulate::import("tabpfn")
+  tabpfn <- .pkg_env$tab_pfn
   cls_wrapper <- function(...) {
     tabpfn$TabPFNClassifier(...)
   }

--- a/R/misc.R
+++ b/R/misc.R
@@ -30,7 +30,7 @@ check_libomp <- function() {
   # reuse it. Only error if libomp came from outside the Python env (e.g. an R
   # package or an OpenMP-enabled R binary), because torch would then try to load
   # its own bundled copy alongside a foreign one, causing a segfault.
-  py_env_root <- dirname(dirname(reticulate::py_exe()))
+  py_env_root <- reticulate::py_config()$prefix
   outside_py_env <- !startsWith(libomp_paths, py_env_root)
 
   if (any(outside_py_env)) {

--- a/R/misc.R
+++ b/R/misc.R
@@ -11,14 +11,29 @@ msg_tabpfn_not_available <- function(cnd) {
 }
 
 check_libomp <- function() {
-  os_info <- Sys.info()['sysname']
+  os_info <- Sys.info()[["sysname"]]
   if (os_info != "Darwin") {
     return(invisible(NULL))
   }
-  vm_types <- system(paste("vmmap", Sys.getpid()), intern = TRUE)
-  has_libomp <- any(grepl("libomp", vm_types))
 
-  if (has_libomp) {
+  vm_types <- system(paste("vmmap", Sys.getpid()), intern = TRUE)
+  libomp_lines <- grep("libomp", vm_types, value = TRUE)
+
+  if (length(libomp_lines) == 0) {
+    return(invisible(NULL))
+  }
+
+  # Extract the file path from each vmmap line (path starts with "/" at end of line)
+  libomp_paths <- sub(".*\\s(/\\S+)\\s*$", "\\1", libomp_lines)
+
+  # libomp loaded from within the active Python environment is fine — torch will
+  # reuse it. Only error if libomp came from outside the Python env (e.g. an R
+  # package or an OpenMP-enabled R binary), because torch would then try to load
+  # its own bundled copy alongside a foreign one, causing a segfault.
+  py_env_root <- dirname(dirname(reticulate::py_exe()))
+  outside_py_env <- !startsWith(libomp_paths, py_env_root)
+
+  if (any(outside_py_env)) {
     cli::cli_abort(
       c(
         i = "We believe that an existing package has loaded {.pkg OpenMP}.",

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,4 +1,5 @@
-tabpfn <- NULL
+.pkg_env <- new.env()
+.pkg_env$tab_pfn <- NULL
 
 .onLoad <- function(...) {
   # Set PyTorch TorchInductor cache to R's temp directory
@@ -11,7 +12,7 @@ tabpfn <- NULL
   reticulate::py_require("tabpfn")
 
   tryCatch(
-    tabpfn <<- reticulate::import(
+    .pkg_env$tab_pfn <- reticulate::import(
       "tabpfn",
       delay_load = list(
         on_error = function(e) {


### PR DESCRIPTION
- In `tab_pfn_impl()`,  the import call now uses the same R object as the one from `.onLoad()`. This ensures that the `check_libomp()` is activated. 
- After `check_libomp()` was activated, false positives were returning. This was addressed by ensuring that the `libomp` identified by `vmmap` is in the same path as the current Python path being used in the R session
