### PR TITLE
add type argument to predict methods

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -38,4 +38,4 @@ Config/testthat/edition: 3
 Encoding: UTF-8
 Language: en-US
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.3
+Config/roxygen2/version: 8.0.0

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # tabpfn (development version)
 
+- Added a `type` argument to be consistent with parsnip. Defaults to `NULL`, which will produce all prediction types. 
+
 # tabpfn 0.2.0
 
 - Updated notes on License Requirements in `?tab_pfn`. 

--- a/R/TabPFN-predict.R
+++ b/R/TabPFN-predict.R
@@ -4,6 +4,9 @@
 #'
 #' @param new_data A data frame or matrix of new predictors.
 #'
+#' @param type The type of prediction. For classification, can be `"class"` or
+#' `"prob"`. Defaults to `NULL` which gives all prediction types possible.
+#'
 #' @param ... Not used, but required for extensibility.
 #'
 #' @return
@@ -34,10 +37,10 @@
 #' }
 #'
 #' @export
-predict.tab_pfn <- function(object, new_data, ...) {
+predict.tab_pfn <- function(object, new_data, type = NULL, ...) {
   rlang::check_dots_empty()
   forged <- hardhat::forge(new_data, object$blueprint)$predictors
-  res <- predict(object$fit, forged, object$levels)
+  res <- predict(object$fit, forged, object$levels, type = type)
   res
 }
 
@@ -49,6 +52,7 @@ predict.tabpfn.regressor.TabPFNRegressor <- function(
   object,
   new_data,
   levels,
+  type = NULL,
   ...
 ) {
   py_msg <- reticulate::py_capture_output(
@@ -70,6 +74,7 @@ predict.tabpfn.classifier.TabPFNClassifier <- function(
   object,
   new_data,
   levels,
+  type = NULL,
   ...
 ) {
   py_msg <- reticulate::py_capture_output(
@@ -87,15 +92,23 @@ predict.tabpfn.classifier.TabPFNClassifier <- function(
     # and "a", object$classes_ will have c("a", "b)
     res$.pred_class <- factor(object$classes_[cls_ind], levels = levels)
   }
+  if (!is.null(type)) {
+    type <- rlang::arg_match(type, c("class", "prob"))
+    if (type == "class") {
+      res <- res[, ".pred_class"]
+    } else if (type == "prob") {
+      res <- res[, names(res) != ".pred_class"]
+    }
+  }
 
   res
 }
 
 #' @export
 #' @rdname predict.tab_pfn
-augment.tab_pfn <- function(x, new_data, ...) {
+augment.tab_pfn <- function(x, new_data, type = NULL, ...) {
   new_data <- tibble::new_tibble(new_data)
-  res <- predict(x, new_data)
+  res <- predict(x, new_data, type = type)
   res <- cbind(res, new_data)
   tibble::new_tibble(res)
 }

--- a/man/predict.tab_pfn.Rd
+++ b/man/predict.tab_pfn.Rd
@@ -5,14 +5,17 @@
 \alias{augment.tab_pfn}
 \title{Predict using \code{TabPFN}}
 \usage{
-\method{predict}{tab_pfn}(object, new_data, ...)
+\method{predict}{tab_pfn}(object, new_data, type = NULL, ...)
 
-\method{augment}{tab_pfn}(x, new_data, ...)
+\method{augment}{tab_pfn}(x, new_data, type = NULL, ...)
 }
 \arguments{
 \item{object, x}{A \code{tab_pfn} object.}
 
 \item{new_data}{A data frame or matrix of new predictors.}
+
+\item{type}{The type of prediction. For classification, can be \code{"class"} or
+\code{"prob"}. Defaults to \code{NULL} which gives all prediction types possible.}
 
 \item{...}{Not used, but required for extensibility.}
 }

--- a/man/reexports.Rd
+++ b/man/reexports.Rd
@@ -11,6 +11,6 @@ These objects are imported from other packages. Follow the links
 below to see their documentation.
 
 \describe{
-  \item{generics}{\code{\link[generics]{augment}}}
+  \item{generics}{\code{\link[generics:augment]{augment()}}}
 }}
 

--- a/man/tabpfn-package.Rd
+++ b/man/tabpfn-package.Rd
@@ -20,6 +20,11 @@ Useful links:
 \author{
 \strong{Maintainer}: Max Kuhn \email{max@posit.co} (\href{https://orcid.org/0000-0003-2402-136X}{ORCID})
 
+Authors:
+\itemize{
+  \item Max Kuhn \email{max@posit.co} (\href{https://orcid.org/0000-0003-2402-136X}{ORCID})
+}
+
 Other contributors:
 \itemize{
   \item Posit Software, PBC (\href{https://ror.org/03wc8by49}{ROR}) [copyright holder, funder]

--- a/tests/testthat/test-classification.R
+++ b/tests/testthat/test-classification.R
@@ -30,6 +30,14 @@ test_that('classification models', {
   expect_equal(pred_df[0, ], pred_ptype)
   expect_equal(nrow(pred_df), 3L)
 
+  pred_cls_df <- predict(mod_df, x_te_df, type = "class")
+  expect_equal(pred_cls_df[0, ], pred_ptype[, ".pred_class"])
+  expect_equal(nrow(pred_cls_df), 3L)
+
+  pred_df <- predict(mod_df, x_te_df, type = "prob")
+  expect_equal(pred_df[0, ], pred_ptype[, 1:2])
+  expect_equal(nrow(pred_df), 3L)
+
   aug_df <- augment(mod_df, x_te_df)
   expect_s3_class(aug_df, c("tbl_df", "tbl", "data.frame"))
   expect_equal(nrow(aug_df), 3L)


### PR DESCRIPTION
This is mostly because parsnip needs specific `type` arguments. 